### PR TITLE
Improve built-in load testing

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -24,12 +24,6 @@ Metadata:
           - kvsDgIntegratorDesiredTaskCount
           - kvsDgIntegratorTaskCpu
           - kvsDgIntegratorTaskMemory
-      - Label:
-          default: "Load Testing"
-        Parameters:
-          - loadTestIsEnabled
-          - loadTestNumSessions
-          - loadTestIntervalMs
 
     ParameterLabels:
       deepgramApi:
@@ -54,12 +48,6 @@ Metadata:
         default: Task CPU
       kvsDgIntegratorTaskMemory:
         default: Task Memory
-      loadTestIsEnabled:
-        default: Enable Load Test
-      loadTestNumSessions:
-        default: Num Sessions
-      loadTestIntervalMs:
-        default: Interval
 
 Parameters:
   deepgramApi:
@@ -137,33 +125,6 @@ Parameters:
       https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html#cfn-ecs-taskdefinition-cpu
     Type: String
     Default: "1024"
-  loadTestIsEnabled:
-    Description: >
-      Do you want to do a load test? This means your calls will be transcribed multiple times to
-      simulate many simultaneous calls. This can be useful for understanding how your configuration
-      will deal with your expected load.
-    Type: String
-    Default: "no"
-    AllowedValues:
-      - "yes"
-      - "no"
-  loadTestNumSessions:
-    Description: >
-      The number of times to transcribe each call. For example, if you set this to 20 and put a call
-      through the system, that call will be transcribed 20 times, simulating 20 concurrent calls.
-      This parameter is only used if load test is enabled.
-    Type: Number
-    Default: "20"
-  loadTestIntervalMs:
-    Description: >
-      The number of milliseconds to wait before triggering each new transcription session. New sessions
-      will be started at this cadence until `Num Sessions` is reached. This parameter is only used
-      if load test is enabled.
-    Type: Number
-    Default: "15000"
-
-Conditions:
-  IsLoadTestEnabled: !Equals [!Ref loadTestIsEnabled, "yes"]
 
 Resources:
   kvsDgTriggerRole:
@@ -200,16 +161,6 @@ Resources:
         Variables:
           KVS_DG_INTEGRATOR_DOMAIN: !GetAtt kvsDgIntegratorLoadBalancer.DNSName
           LOG_LEVEL: !Ref kvsDgTriggerLogLevel
-          LOAD_TEST_NUM_SESSIONS:
-            Fn::If:
-              - IsLoadTestEnabled
-              - !Ref loadTestNumSessions
-              - "1"
-          LOAD_TEST_INTERVAL_MS:
-            Fn::If:
-              - IsLoadTestEnabled
-              - !Ref loadTestIntervalMs
-              - "0"
       PackageType: "Image"
       Code:
         ImageUri: !Ref kvsDgTriggerImage
@@ -224,11 +175,7 @@ Resources:
       ClusterName: kvs-dg-integrator-cluster
       ClusterSettings:
         - Name: containerInsights
-          Value:
-            Fn::If:
-              - IsLoadTestEnabled
-              - "enabled"
-              - "disabled"
+          Value: "disabled" # If you are load testing, setting this to "enabled" can reveal useful info
 
   kvsDgIntegratorExecutionRole:
     Type: "AWS::IAM::Role"
@@ -293,12 +240,6 @@ Resources:
               Value: !Ref kvsDgIntegratorLogLevel
             - Name: APP_REGION
               Value: !Ref "AWS::Region"
-            - Name: ENFORCE_REALTIME
-              Value:
-                Fn::If:
-                  - IsLoadTestEnabled
-                  - "true"
-                  - "false"
           PortMappings:
             - HostPort: 80
               ContainerPort: 80

--- a/kvs_dg_integrator/src/main/java/com/deepgram/kvsdgintegrator/IntegratorArguments.java
+++ b/kvs_dg_integrator/src/main/java/com/deepgram/kvsdgintegrator/IntegratorArguments.java
@@ -17,16 +17,19 @@ import java.util.*;
 public record IntegratorArguments(
         String contactId,
         KvsStream kvsStream,
-        @JsonDeserialize(using = DgParamsDeserializer.class) Map<String, List<String>> dgParams) {
+        @JsonDeserialize(using = DgParamsDeserializer.class) Map<String, List<String>> dgParams,
+        boolean enforceRealtime) {
     @JsonCreator
     public IntegratorArguments(
             @JsonProperty(required = true, value = "contactId") String contactId,
             @JsonProperty(required = true, value = "kvsStream") KvsStream kvsStream,
-            @JsonProperty(required = true, value = "dgParams") Map<String, List<String>> dgParams
+            @JsonProperty(required = true, value = "dgParams") Map<String, List<String>> dgParams,
+            @JsonProperty(required = true, value = "enforceRealtime") boolean enforceRealtime
     ) {
         this.contactId = Validate.notNull(contactId);
         this.kvsStream = Validate.notNull(kvsStream);
         this.dgParams = Validate.notNull(dgParams);
+        this.enforceRealtime = enforceRealtime;
     }
 
     private static class DgParamsDeserializer extends JsonDeserializer<Map<String, List<String>>> {

--- a/kvs_dg_integrator/src/main/java/com/deepgram/kvsdgintegrator/KvsToDgStreamer.java
+++ b/kvs_dg_integrator/src/main/java/com/deepgram/kvsdgintegrator/KvsToDgStreamer.java
@@ -31,12 +31,12 @@ public class KvsToDgStreamer {
 	public static void doStreamingSession(
 			IntegratorArguments integratorArguments,
 			String deepgramApi,
-			String deepgramApiKey,
-			boolean enforceRealtime
+			String deepgramApiKey
 	) throws Exception {
 		String streamARN = integratorArguments.kvsStream().arn();
 		String startFragmentNum = integratorArguments.kvsStream().startFragmentNumber();
 		String contactId = integratorArguments.contactId();
+		boolean enforceRealtime = integratorArguments.enforceRealtime();
 
 		String streamName = streamARN.substring(streamARN.indexOf("/") + 1, streamARN.lastIndexOf("/"));
 

--- a/kvs_dg_integrator/src/main/java/com/deepgram/kvsdgintegrator/Launcher.java
+++ b/kvs_dg_integrator/src/main/java/com/deepgram/kvsdgintegrator/Launcher.java
@@ -37,10 +37,6 @@ public class Launcher {
 			return;
 		}
 
-		String enforceRealtimeStr = System.getenv("ENFORCE_REALTIME");
-		boolean enforceRealtime = enforceRealtimeStr != null && enforceRealtimeStr.equalsIgnoreCase("true");
-		logger.info("Enforce realtime = " + enforceRealtime);
-
 		Warmer.warmUpApplication();
 		logger.info("Application warmup complete");
 
@@ -52,7 +48,7 @@ public class Launcher {
 				throw new RuntimeException(e);
 			}
 		});
-		server.createContext("/start-session", new StartSessionHandler(deepgramApi, deepgramApiKey, enforceRealtime));
+		server.createContext("/start-session", new StartSessionHandler(deepgramApi, deepgramApiKey));
 		server.setExecutor(Executors.newCachedThreadPool());
 		server.start();
 	}
@@ -60,13 +56,11 @@ public class Launcher {
 	static class StartSessionHandler implements HttpHandler {
 		private final String deepgramApi;
 		private final String deepgramApiKey;
-		private final boolean enforceRealtime;
 		private static final Logger logger = LogManager.getLogger(StartSessionHandler.class);
 
-		public StartSessionHandler(String deepgramApi, String deepgramApiKey, boolean enforceRealtime) {
+		public StartSessionHandler(String deepgramApi, String deepgramApiKey) {
 			this.deepgramApi = Validate.notNull(deepgramApi);
 			this.deepgramApiKey = Validate.notNull(deepgramApiKey);
-			this.enforceRealtime = enforceRealtime;
 		}
 
 		@Override
@@ -108,7 +102,7 @@ public class Launcher {
 
 			try {
 				KvsToDgStreamer.doStreamingSession(
-						integratorArguments, this.deepgramApi, this.deepgramApiKey, this.enforceRealtime);
+						integratorArguments, this.deepgramApi, this.deepgramApiKey);
 			} catch (Exception e) {
 				logger.error("Exception during integrator session", e);
 				return;

--- a/kvs_dg_integrator/src/test/java/com/deepgram/kvsdgintegrator/IntegratorArgumentsTests.java
+++ b/kvs_dg_integrator/src/test/java/com/deepgram/kvsdgintegrator/IntegratorArgumentsTests.java
@@ -24,7 +24,8 @@ class IntegratorArgumentsTests {
                         "model": "nova",
                         "tag": ["someTag1", "someTag2"],
                         "callback": "https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"
-                    }
+                    },
+                    "enforceRealtime": true
                 }""";
         IntegratorArguments expected = new IntegratorArguments(
                 "4a573372-1f28-4e26-b97b-XXXXXXXXXXX",
@@ -33,8 +34,9 @@ class IntegratorArgumentsTests {
                         "100"),
                 Map.of("model", List.of("nova"),
                         "tag", List.of("someTag1", "someTag2"),
-                        "callback", List.of("https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"))
-                );
+                        "callback", List.of("https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX")),
+                true
+        );
         IntegratorArguments actual = IntegratorArguments.fromJson(json);
         assertEquals(expected, actual);
     }
@@ -53,6 +55,7 @@ class IntegratorArgumentsTests {
                         "tag": ["someTag1", "someTag2"],
                         "callback": "https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"
                     },
+                    "enforceRealtime": true,
                     "something": "else"
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
@@ -70,7 +73,8 @@ class IntegratorArgumentsTests {
                         "model": "nova",
                         "tag": ["someTag1", "someTag2"],
                         "callback": "https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"
-                    }
+                    },
+                    "enforceRealtime": true
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
     }
@@ -84,7 +88,8 @@ class IntegratorArgumentsTests {
                         "model": "nova",
                         "tag": ["someTag1", "someTag2"],
                         "callback": "https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"
-                    }
+                    },
+                    "enforceRealtime": true
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
     }
@@ -97,7 +102,8 @@ class IntegratorArgumentsTests {
                     "kvsStream": {
                         "arn": "arn:aws:kinesisvideo::eu-west-2:111111111111:stream/instance-alias-contact-ddddddd-bbbb-dddd-eeee-ffffffffffff/9999999999999",
                         "startFragmentNumber": "100"
-                    }
+                    },
+                    "enforceRealtime": true
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
     }
@@ -115,7 +121,8 @@ class IntegratorArgumentsTests {
                         "model": "nova",
                         "tag": ["someTag1", "someTag2"],
                         "callback": "https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"
-                    }
+                    },
+                    "enforceRealtime": true
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
     }
@@ -130,7 +137,8 @@ class IntegratorArgumentsTests {
                         "model": "nova",
                         "tag": ["someTag1", "someTag2"],
                         "callback": "https://example.com/4a573372-1f28-4e26-b97b-XXXXXXXXXXX"
-                    }
+                    },
+                    "enforceRealtime": true
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
     }
@@ -144,7 +152,8 @@ class IntegratorArgumentsTests {
                         "arn": "arn:aws:kinesisvideo::eu-west-2:111111111111:stream/instance-alias-contact-ddddddd-bbbb-dddd-eeee-ffffffffffff/9999999999999",
                         "startFragmentNumber": "100"
                     },
-                    "dgParams": null
+                    "dgParams": null,
+                    "enforceRealtime": true
                 }""";
         assertThrows(Exception.class, () -> IntegratorArguments.fromJson(json));
     }

--- a/kvs_dg_trigger/lambda_function_test.py
+++ b/kvs_dg_trigger/lambda_function_test.py
@@ -71,3 +71,15 @@ class TestGetDgParams(unittest.TestCase):
         actual_dg_params = lambda_function.get_dg_params(contact_attrs, contact_id)
 
         self.assertIsNone(actual_dg_params)
+
+    def test_unset(self):
+        contact_attrs = {
+            "dg_model": "nova",
+            "dg_callback": "UNSET",
+            "dg_tag": "abc",
+        }
+        contact_id = "11112222-3333-4444-5555-aaaabbbbcccc"
+        expected_dg_params = {"model": "nova", "tag": ["abc", "dg_amazonconnect"]}
+        actual_dg_params = lambda_function.get_dg_params(contact_attrs, contact_id)
+
+        self.assertEqual(actual_dg_params, expected_dg_params)

--- a/sample_contact_flow.json
+++ b/sample_contact_flow.json
@@ -281,7 +281,7 @@
         },
         {
             "Parameters": {
-                "Text": "Lambda function failed or timed out. If you are running a load test, timing out is expected and fine."
+                "Text": "Lambda function failed or timed out."
             },
             "Identifier": "3f9659a3-56a5-4f3c-a431-fd9da2306459",
             "Type": "MessageParticipant",

--- a/sample_contact_flow_load_test.json
+++ b/sample_contact_flow_load_test.json
@@ -1,0 +1,632 @@
+{
+    "Version": "2019-10-30",
+    "StartAction": "856dd865-e5a0-49c6-aacc-55fe53c38a22",
+    "Metadata": {
+        "entryPointPosition": {
+            "x": 20,
+            "y": 18.4
+        },
+        "ActionMetadata": {
+            "3c0a2902-d59f-4da9-a565-97f8d7d5519a": {
+                "position": {
+                    "x": 873.6,
+                    "y": 285.6
+                }
+            },
+            "410057d0-9390-486b-bbb4-c4def2a7367c": {
+                "position": {
+                    "x": 524,
+                    "y": 211.2
+                }
+            },
+            "af86e23d-382a-4cf8-b4af-e7db3b823ca2": {
+                "position": {
+                    "x": 874.4,
+                    "y": 483.2
+                }
+            },
+            "121525e4-e75e-42d3-9565-dcbfda0e1126": {
+                "position": {
+                    "x": 881.6,
+                    "y": 934.4
+                }
+            },
+            "Play 100 mins of silence": {
+                "position": {
+                    "x": 534.4,
+                    "y": 1374.4
+                },
+                "isFriendlyName": true
+            },
+            "99458f47-6941-48ce-9b90-fdf184759b22": {
+                "position": {
+                    "x": 1232.8,
+                    "y": 1425.6
+                }
+            },
+            "Play 1 min of silence": {
+                "position": {
+                    "x": 877.6,
+                    "y": 1371.2
+                },
+                "isFriendlyName": true
+            },
+            "6a837184-f7aa-4445-89fb-31c3ade5b9fc": {
+                "position": {
+                    "x": 879.2,
+                    "y": 692.8
+                }
+            },
+            "96d92aac-244a-45cf-9487-4c3f6301d5c2": {
+                "position": {
+                    "x": 182.4,
+                    "y": 1380.8
+                }
+            },
+            "856dd865-e5a0-49c6-aacc-55fe53c38a22": {
+                "position": {
+                    "x": 185.6,
+                    "y": 14.4
+                }
+            },
+            "cde4015e-aa9b-4fa2-8ce8-0042fccbd70b": {
+                "position": {
+                    "x": 872.8,
+                    "y": 98.4
+                }
+            },
+            "d5bd7724-4436-4bfc-bd2a-d0bee26963a1": {
+                "position": {
+                    "x": 521.6,
+                    "y": 0
+                }
+            },
+            "a41e78a9-df03-4011-99b0-50077c0bcd63": {
+                "position": {
+                    "x": 527.2,
+                    "y": 862.4
+                }
+            },
+            "a31ce016-12db-4e5d-8390-4760fdaa0f86": {
+                "position": {
+                    "x": 1573.6,
+                    "y": 1151.2
+                }
+            },
+            "4171b9a2-268b-4435-9a35-59dab368e0f5": {
+                "position": {
+                    "x": 522.4,
+                    "y": 416
+                }
+            },
+            "6728609a-9707-41f7-a87c-30ac1fde4f4c": {
+                "position": {
+                    "x": 185.6,
+                    "y": 204.8
+                },
+                "toCustomer": true,
+                "fromCustomer": true
+            },
+            "3f9659a3-56a5-4f3c-a431-fd9da2306459": {
+                "position": {
+                    "x": 523.2,
+                    "y": 632.8
+                }
+            },
+            "Subsequent Sessions Configuration": {
+                "position": {
+                    "x": 190.4,
+                    "y": 861.6
+                },
+                "isFriendlyName": true,
+                "dynamicParams": []
+            },
+            "First Session Configuration": {
+                "position": {
+                    "x": 187.2,
+                    "y": 412
+                },
+                "isFriendlyName": true,
+                "dynamicParams": []
+            },
+            "Invoke Trigger Lambda": {
+                "position": {
+                    "x": 189.6,
+                    "y": 632
+                },
+                "isFriendlyName": true,
+                "dynamicMetadata": {}
+            },
+            "c822ffc4-83da-4933-bfff-bf036cfc5e50": {
+                "position": {
+                    "x": 1227.2,
+                    "y": 1111.2
+                }
+            },
+            "Trigger Subsequent Sessions": {
+                "position": {
+                    "x": 184.8,
+                    "y": 1114.4
+                },
+                "isFriendlyName": true
+            },
+            "Play 2 seconds of silence": {
+                "position": {
+                    "x": 531.2,
+                    "y": 1112.8
+                },
+                "isFriendlyName": true
+            },
+            "Invoke Subsequent Trigger Lambda": {
+                "position": {
+                    "x": 880,
+                    "y": 1112
+                },
+                "isFriendlyName": true,
+                "dynamicMetadata": {}
+            }
+        },
+        "Annotations": [
+            {
+                "type": "default",
+                "id": "0bd14c82-fa52-4d48-b015-4e11d01db7c7",
+                "content": "Swap your callback URL into this block to receive the transcripts of the first session. Once all of the sessions have started, you can talk into the call and watch the transcripts to observe the latency at peak load. ",
+                "actionId": "First Session Configuration",
+                "isFolded": true,
+                "position": {
+                    "x": 253.16666666666666,
+                    "y": 721.6666666666666
+                },
+                "size": {
+                    "height": 295,
+                    "width": 300
+                }
+            },
+            {
+                "type": "default",
+                "id": "302aa7be-a3b8-467f-b1ff-66df21c69cc8",
+                "content": "Swap in your trigger lambda here.",
+                "actionId": "Invoke Trigger Lambda",
+                "isFolded": true,
+                "position": {
+                    "x": 256.1666666666667,
+                    "y": 996.6666666666666
+                },
+                "size": {
+                    "height": 295,
+                    "width": 300
+                }
+            },
+            {
+                "type": "default",
+                "id": "8c4b4f32-fc59-4ec8-be5e-24a87932f737",
+                "content": "This block makes subsequent sessions in the load test behave differently than the first session. There are two differences:\n\n1. Only the first session uses a callback. This way you can watch the callbacks coming into your callback URL and not be confused about which session they're part of.\n\n2. The first session allows the audio to be passed to Deepgram as quickly as possible, but subsequent sessions enforce a realtime rate. Enforcing realtime is important because the later sessions are being initiated well after the \"Start Media Streaming\" block, so by default the integration would try to pull audio very quickly to catch up. In order to have those later sessions behave like normal calls, we have to disable that catch-up behavior.",
+                "actionId": "Subsequent Sessions Configuration",
+                "isFolded": true,
+                "position": {
+                    "x": 257.1666666666667,
+                    "y": 1283.6666666666667
+                },
+                "size": {
+                    "height": 295,
+                    "width": 300
+                }
+            },
+            {
+                "type": "default",
+                "id": "f72b2e2e-f885-4730-b363-92a6166cb3d5",
+                "content": "Swap in your trigger lambda here.",
+                "actionId": "Invoke Subsequent Trigger Lambda",
+                "isFolded": true,
+                "position": {
+                    "x": 1119.1666666666667,
+                    "y": 1596.6666666666667
+                },
+                "size": {
+                    "height": 295,
+                    "width": 300
+                }
+            },
+            {
+                "type": "default",
+                "id": "a3cf77a4-0fbd-4833-8320-4b3d0b4d7c5f",
+                "content": "Modify this block to choose the interval at which new sessions are started in the load test.",
+                "actionId": "Play 2 seconds of silence",
+                "isFolded": true,
+                "position": {
+                    "x": 683.1666666666666,
+                    "y": 1597.6666666666667
+                },
+                "size": {
+                    "height": 295,
+                    "width": 300
+                }
+            },
+            {
+                "type": "default",
+                "id": "ab7300be-732b-4114-bebf-f1bb966d1360",
+                "content": "Modify this block to choose the number of total sessions the load test should be running at its peak. The number is really 1 more than the number of loop iterations you choose here.",
+                "actionId": "Trigger Subsequent Sessions",
+                "isFolded": true,
+                "position": {
+                    "x": 250.16666666666666,
+                    "y": 1599.6666666666667
+                },
+                "size": {
+                    "height": 295,
+                    "width": 300
+                }
+            }
+        ],
+        "name": "Sample Deepgram Load Test flow",
+        "description": "",
+        "type": "contactFlow",
+        "status": "saved",
+        "hash": {}
+    },
+    "Actions": [
+        {
+            "Parameters": {},
+            "Identifier": "3c0a2902-d59f-4da9-a565-97f8d7d5519a",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {
+                "Text": "Error starting streaming."
+            },
+            "Identifier": "410057d0-9390-486b-bbb4-c4def2a7367c",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "3c0a2902-d59f-4da9-a565-97f8d7d5519a",
+                "Errors": [
+                    {
+                        "NextAction": "3c0a2902-d59f-4da9-a565-97f8d7d5519a",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {},
+            "Identifier": "af86e23d-382a-4cf8-b4af-e7db3b823ca2",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {},
+            "Identifier": "121525e4-e75e-42d3-9565-dcbfda0e1126",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {
+                "LoopCount": "100"
+            },
+            "Identifier": "Play 100 mins of silence",
+            "Type": "Loop",
+            "Transitions": {
+                "NextAction": "99458f47-6941-48ce-9b90-fdf184759b22",
+                "Conditions": [
+                    {
+                        "NextAction": "Play 1 min of silence",
+                        "Condition": {
+                            "Operator": "Equals",
+                            "Operands": [
+                                "ContinueLooping"
+                            ]
+                        }
+                    },
+                    {
+                        "NextAction": "99458f47-6941-48ce-9b90-fdf184759b22",
+                        "Condition": {
+                            "Operator": "Equals",
+                            "Operands": [
+                                "DoneLooping"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {},
+            "Identifier": "99458f47-6941-48ce-9b90-fdf184759b22",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {
+                "SSML": "<speak>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n<break time=\"5000ms\"/>\n</speak>"
+            },
+            "Identifier": "Play 1 min of silence",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "Play 100 mins of silence",
+                "Errors": [
+                    {
+                        "NextAction": "99458f47-6941-48ce-9b90-fdf184759b22",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {},
+            "Identifier": "6a837184-f7aa-4445-89fb-31c3ade5b9fc",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {
+                "Text": "All load testing sessions have been started."
+            },
+            "Identifier": "96d92aac-244a-45cf-9487-4c3f6301d5c2",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "Play 100 mins of silence",
+                "Errors": [
+                    {
+                        "NextAction": "99458f47-6941-48ce-9b90-fdf184759b22",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "FlowLoggingBehavior": "Enabled"
+            },
+            "Identifier": "856dd865-e5a0-49c6-aacc-55fe53c38a22",
+            "Type": "UpdateFlowLoggingBehavior",
+            "Transitions": {
+                "NextAction": "d5bd7724-4436-4bfc-bd2a-d0bee26963a1"
+            }
+        },
+        {
+            "Parameters": {},
+            "Identifier": "cde4015e-aa9b-4fa2-8ce8-0042fccbd70b",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {
+                "Text": "This call will run a load test on your Deepgram integration."
+            },
+            "Identifier": "d5bd7724-4436-4bfc-bd2a-d0bee26963a1",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "6728609a-9707-41f7-a87c-30ac1fde4f4c",
+                "Errors": [
+                    {
+                        "NextAction": "cde4015e-aa9b-4fa2-8ce8-0042fccbd70b",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "Text": "Error setting subsequent calls contact attributes"
+            },
+            "Identifier": "a41e78a9-df03-4011-99b0-50077c0bcd63",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "121525e4-e75e-42d3-9565-dcbfda0e1126",
+                "Errors": [
+                    {
+                        "NextAction": "121525e4-e75e-42d3-9565-dcbfda0e1126",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {},
+            "Identifier": "a31ce016-12db-4e5d-8390-4760fdaa0f86",
+            "Type": "DisconnectParticipant",
+            "Transitions": {}
+        },
+        {
+            "Parameters": {
+                "Text": "Error setting first call contact attributes."
+            },
+            "Identifier": "4171b9a2-268b-4435-9a35-59dab368e0f5",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "af86e23d-382a-4cf8-b4af-e7db3b823ca2",
+                "Errors": [
+                    {
+                        "NextAction": "af86e23d-382a-4cf8-b4af-e7db3b823ca2",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "MediaStreamingState": "Enabled",
+                "MediaStreamType": "Audio",
+                "Participants": [
+                    {
+                        "ParticipantType": "Customer",
+                        "MediaDirections": [
+                            "To",
+                            "From"
+                        ]
+                    }
+                ]
+            },
+            "Identifier": "6728609a-9707-41f7-a87c-30ac1fde4f4c",
+            "Type": "UpdateContactMediaStreamingBehavior",
+            "Transitions": {
+                "NextAction": "First Session Configuration",
+                "Errors": [
+                    {
+                        "NextAction": "410057d0-9390-486b-bbb4-c4def2a7367c",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "Text": "Lambda function failed or timed out."
+            },
+            "Identifier": "3f9659a3-56a5-4f3c-a431-fd9da2306459",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "6a837184-f7aa-4445-89fb-31c3ade5b9fc",
+                "Errors": [
+                    {
+                        "NextAction": "6a837184-f7aa-4445-89fb-31c3ade5b9fc",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "Attributes": {
+                    "dg_callback": "UNSET",
+                    "dgintegrator_enforcerealtime": "true"
+                },
+                "TargetContact": "Current"
+            },
+            "Identifier": "Subsequent Sessions Configuration",
+            "Type": "UpdateContactAttributes",
+            "Transitions": {
+                "NextAction": "Trigger Subsequent Sessions",
+                "Errors": [
+                    {
+                        "NextAction": "a41e78a9-df03-4011-99b0-50077c0bcd63",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "Attributes": {
+                    "dg_model": "nova",
+                    "dg_tag": "loadTest",
+                    "dg_callback": "https://YOUR-ENDPOINT-HERE.com"
+                },
+                "TargetContact": "Current"
+            },
+            "Identifier": "First Session Configuration",
+            "Type": "UpdateContactAttributes",
+            "Transitions": {
+                "NextAction": "Invoke Trigger Lambda",
+                "Errors": [
+                    {
+                        "NextAction": "4171b9a2-268b-4435-9a35-59dab368e0f5",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "LambdaFunctionARN": "",
+                "InvocationTimeLimitSeconds": "8",
+                "ResponseValidation": {
+                    "ResponseType": "STRING_MAP"
+                }
+            },
+            "Identifier": "Invoke Trigger Lambda",
+            "Type": "InvokeLambdaFunction",
+            "Transitions": {
+                "NextAction": "Subsequent Sessions Configuration",
+                "Errors": [
+                    {
+                        "NextAction": "3f9659a3-56a5-4f3c-a431-fd9da2306459",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "Text": "Lambda function failed or timed out."
+            },
+            "Identifier": "c822ffc4-83da-4933-bfff-bf036cfc5e50",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "a31ce016-12db-4e5d-8390-4760fdaa0f86",
+                "Errors": [
+                    {
+                        "NextAction": "a31ce016-12db-4e5d-8390-4760fdaa0f86",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "LoopCount": "89"
+            },
+            "Identifier": "Trigger Subsequent Sessions",
+            "Type": "Loop",
+            "Transitions": {
+                "NextAction": "96d92aac-244a-45cf-9487-4c3f6301d5c2",
+                "Conditions": [
+                    {
+                        "NextAction": "Play 2 seconds of silence",
+                        "Condition": {
+                            "Operator": "Equals",
+                            "Operands": [
+                                "ContinueLooping"
+                            ]
+                        }
+                    },
+                    {
+                        "NextAction": "96d92aac-244a-45cf-9487-4c3f6301d5c2",
+                        "Condition": {
+                            "Operator": "Equals",
+                            "Operands": [
+                                "DoneLooping"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "SSML": "<speak>\n<break time=\"2000ms\"/>\n</speak>"
+            },
+            "Identifier": "Play 2 seconds of silence",
+            "Type": "MessageParticipant",
+            "Transitions": {
+                "NextAction": "Invoke Subsequent Trigger Lambda",
+                "Errors": [
+                    {
+                        "NextAction": "a31ce016-12db-4e5d-8390-4760fdaa0f86",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        },
+        {
+            "Parameters": {
+                "LambdaFunctionARN": "",
+                "InvocationTimeLimitSeconds": "8",
+                "ResponseValidation": {
+                    "ResponseType": "STRING_MAP"
+                }
+            },
+            "Identifier": "Invoke Subsequent Trigger Lambda",
+            "Type": "InvokeLambdaFunction",
+            "Transitions": {
+                "NextAction": "Trigger Subsequent Sessions",
+                "Errors": [
+                    {
+                        "NextAction": "c822ffc4-83da-4933-bfff-bf036cfc5e50",
+                        "ErrorType": "NoMatchingError"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Our Amazon Connect integration offers built-in load testing functionality. This PR makes it easier to use and more flexible.

For a high-level view of how the integration works, see the [Architecture Overview](https://developers.deepgram.com/docs/deepgram-with-amazon-connect#architecture-overview) section of the docs. 

### Load Testing Background
The general idea is that we load test the integration by putting a single call through Connect, but triggering many integrator sessions for that call. Each session transcribes the full call. From the integrator's perspective, this is the same as handling many *different* calls, so it reveals to us how the integration will perform under that number of concurrent calls.

### These Changes
Before this PR, the contact flow would call the trigger lambda once, which would kick off many integrator sessions. After this PR, the contact flow calls the trigger lambda many times, and the trigger lambda always kicks off exactly one integrator session. This allows us to simplify the trigger lambda, pushing its logic into the contact flow. This is a big improvement because the user has free reign over the contact flow and can adjust the logic to their needs, whereas the trigger lambda can't be as easily updated.

In particular, these changes make it easy to observe the transcripts for just one of the calls during a load test, which gives a qualitative measure of latency under the load in question.